### PR TITLE
Fix GitHub Actions workflow for Android builds

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -43,14 +43,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - name: Make gradlew executable
-        run: chmod +x ./gradlew
-
-      - name: Build Debug APK
-        run: ./gradlew --no-daemon assembleDebug
+      - name: Build Debug APK (no wrapper)
+        uses: gradle/gradle-build-action@v3
+        with:
+          gradle-version: 8.8
+          arguments: assembleDebug
+          build-root-directory: Lean9App
 
       - name: Upload APK artifact
         uses: actions/upload-artifact@v4
         with:
           name: Lean9App-debug
-          path: app/build/outputs/apk/debug/app-debug.apk
+          path: Lean9App/app/build/outputs/apk/debug/app-debug.apk


### PR DESCRIPTION
This change corrects the GitHub Actions workflow to successfully build the Android `.apk`.

The following fixes were implemented based on user feedback:
- Replaced the direct `gradlew` commands with the `gradle/gradle-build-action@v3`. This removes the need for a Gradle wrapper in the repository and provides a more robust build environment.
- Specified the `build-root-directory` for the build action to ensure Gradle runs in the `Lean9App` sub-directory.
- Corrected the `path` for the `upload-artifact` step to correctly locate the generated `.apk` file.