### PR TITLE
Add PWA icons to manifest

### DIFF
--- a/LeanIntervalTimerPWA/public/manifest.json
+++ b/LeanIntervalTimerPWA/public/manifest.json
@@ -4,5 +4,17 @@
   "start_url": "/index.html",
   "display": "standalone",
   "background_color": "#0b0b0c",
-  "theme_color": "#ff6a00"
+  "theme_color": "#ff6a00",
+  "icons": [
+    {
+      "src": "icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- add 192x192 and 512x512 icon definitions to the PWA manifest

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c616adac708320ba96b5255a6c4f7e