### PR TITLE
Add manual exercise navigation controls

### DIFF
--- a/Lean9.html
+++ b/Lean9.html
@@ -38,6 +38,8 @@
     .stack{gap:42px}
     .stack .stacked{display:grid;gap:4px;justify-items:center}
     .wc-text{color:var(--text-strong);text-align:center;font-weight:600}
+    .control-row{display:flex;justify-content:center;gap:12px;padding-top:8px}
+    .control-row button{min-width:110px}
 
     .exercises{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:10px;padding:0 18px 6px}
     .exercise{border:1px solid var(--ring);border-radius:12px;padding:12px 10px;min-height:70px;text-align:center;display:grid;place-items:center;background:#0f1116}
@@ -123,6 +125,10 @@
               <div class="muted">Cooldown</div>
               <div class="wc-text" id="cooldown">—</div>
             </div>
+          </div>
+          <div class="control-row">
+            <button id="prevExercise" class="btn-secondary" title="Go back to the previous exercise">◀ Back</button>
+            <button id="nextExercise" class="btn-secondary" title="Skip to the next exercise">Next ▶</button>
           </div>
         </div>
         <div class="exercises" id="exList">
@@ -597,6 +603,66 @@ const builtInData = [
       }
     }
 
+    function jumpExercise(direction){
+      if(!direction) return;
+      const entry = state.data[state.idxWorkout];
+      if(!entry) return;
+      if(state.phase==='done') return;
+
+      if(direction > 0){
+        if(state.phase==='getready'){
+          state.phase='work';
+          state.seconds=state.work;
+          setActiveExercise();
+          playWork();
+          renderMeta();
+          persistInProgress();
+          return;
+        }
+        let nextRound = state.round;
+        let nextEx = state.exIdx + 1;
+        if(nextEx >= 3){
+          nextEx = 0;
+          if(nextRound < state.rounds){
+            nextRound++;
+          } else {
+            finish();
+            return;
+          }
+        }
+        state.round = nextRound;
+        state.exIdx = nextEx;
+        state.phase='work';
+        state.seconds=state.work;
+        setActiveExercise();
+        playWork();
+        renderMeta();
+        persistInProgress();
+        return;
+      }
+
+      if(state.phase==='getready') return;
+
+      let prevRound = state.round;
+      let prevEx = state.exIdx - 1;
+      if(prevEx < 0){
+        if(prevRound > 1){
+          prevRound--;
+          prevEx = 2;
+        } else {
+          prevEx = 0;
+        }
+      }
+      state.round = prevRound;
+      state.exIdx = prevEx;
+      state.phase='work';
+      state.seconds=state.work;
+      setActiveExercise();
+      playWork();
+      renderMeta();
+      persistInProgress();
+    }
+
     function tick(){
       if(state.phase==='getready' && state.seconds<=3 && state.seconds>0) playCountdown();
       // prepare music mute window: 2s before and 2s after each WORK/REST switch
@@ -634,6 +700,8 @@ const builtInData = [
       if(res){ const i = res.idxWorkout||0; selectWorkout(i,false); applySnapshot(res); startPause(); return; }
       const next = state.data.findIndex((d,i)=> !(prog[uid(d,i)]?.done)); const idx = next>=0? next : 0; selectWorkout(idx,true);
     });
+    $('#nextExercise').addEventListener('click', ()=> jumpExercise(1));
+    $('#prevExercise').addEventListener('click', ()=> jumpExercise(-1));
     $('#loadFile').addEventListener('click',()=> $('#filePicker').click());
     $('#filePicker').addEventListener('change', async (e)=>{ const file = e.target.files?.[0]; if(!file) return; const txt = await file.text(); const arr = parseCyclesText(txt); if(!Array.isArray(arr)){ alert('Could not parse file. Use JSON [ {...}, ... ] or JS-like: const data = [ {...}, ... ];'); return; } setData(arr); });
     $('#musicBtn').addEventListener('click', toggleMusic);


### PR DESCRIPTION
## Summary
- add back/next controls to the timer display for manual exercise navigation
- implement jumpExercise logic to advance or rewind the workout state and persist progress
- wire the new controls into the existing UI update flow

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68c9d08efe3c8320a5f7da6a3dcdc352